### PR TITLE
Fix print statement throwing NullReferenceException

### DIFF
--- a/src/Syntax/Parser.cs
+++ b/src/Syntax/Parser.cs
@@ -916,8 +916,8 @@ eval_input: testlist NEWLINE* ENDMARKER
                     for (; ; )
                     {
                         var tok = lexer.Peek();
-                        if (tok.Type == TokenType.EOF &&
-                            tok.Type == TokenType.NEWLINE &&
+                        if (tok.Type == TokenType.EOF ||
+                            tok.Type == TokenType.NEWLINE ||
                             tok.Type == TokenType.SEMI)
                             break;
                         var a = test();


### PR DESCRIPTION
[V3022](https://www.viva64.com/en/w/V3022) Expression is always false. Probably the '||' operator should be used here. Parser.cs 919

Steps to reproduce:
- Run converter with input:
 `print ;`
or
`print`
which are valid python scripts (both printing a single blank line)
- Observe that `NullReferenceException` is thrown on line
 `args.Add(new Argument(null, a, filename, a.Start, a.End));`
(`a == null`)
and resulting C# output is empty

Analysed using [PVS-Studio](https://www.viva64.com/en/pvs-studio/) as a part of [pinguem.ru](https://pinguem.ru) competition