### PR TITLE
Fix Incorrect format exception

### DIFF
--- a/src/Syntax/Lexer.cs
+++ b/src/Syntax/Lexer.cs
@@ -17,6 +17,7 @@
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -985,7 +986,7 @@ namespace Pytocs.Syntax
 
         private Token Real()
         {
-            return Token(TokenType.REAL, Convert.ToDouble(sb.ToString()), State.Base);
+            return Token(TokenType.REAL, Convert.ToDouble(sb.ToString(), CultureInfo.InvariantCulture), State.Base);
         }
     }
 }


### PR DESCRIPTION
If current thread culture is considered to accept comma in numbers instead of the point (ex: 1,0 instead of 1.0) it threw an exception,