### PR TITLE
Statement "for" in Statement translator extended for attribute access.

### DIFF
--- a/src/Translate/StatementTranslator.Tests.cs
+++ b/src/Translate/StatementTranslator.Tests.cs
@@ -1020,6 +1020,29 @@ yx = _tup_1.Item1;
         }
 
         [Test]
+        public void Stmt_foreach_class_property()
+        {
+            var pySrc =
+@"for self.target_addr in targets:
+    if self.target_addr is None:
+        addr_strs.append(""default"")
+    else:
+        addr_strs.append(""%#x"" % target_addr)
+";
+            var sExp =
+@"foreach (var _tup_1 in targets) {
+    this.target_addr = _tup_1;
+    if (this.target_addr == null) {
+        addr_strs.append(""default"");
+    } else {
+        addr_strs.append(String.Format(""%#x"", target_addr));
+    }
+}
+";
+            Assert.AreEqual(sExp, XlatStmts(pySrc));
+        }
+
+        [Test]
         public void Stmt_Tuple_Assign()
         {
             var pySrc =

--- a/src/Translate/StatementTranslator.cs
+++ b/src/Translate/StatementTranslator.cs
@@ -79,7 +79,7 @@ namespace Pytocs.Translate
                         result[dec] = propdef;
                         propdef.Getter = dec;
                         propdef.GetterDecoration = decoration;
-                    } 
+                    }
                     if (IsSetterDecorator(decoration))
                     {
                         var def = (FunctionDef)dec.Statement;
@@ -93,7 +93,7 @@ namespace Pytocs.Translate
             return result;
         }
 
-        private static PropertyDefinition  EnsurePropertyDefinition(Dictionary<string, PropertyDefinition> propdefs, FunctionDef def)
+        private static PropertyDefinition EnsurePropertyDefinition(Dictionary<string, PropertyDefinition> propdefs, FunctionDef def)
         {
             if (!propdefs.TryGetValue(def.name.Name, out var propdef))
             {
@@ -132,7 +132,7 @@ namespace Pytocs.Translate
             var suiteStmt = statements[i] as SuiteStatement;
             if (suiteStmt == null)
                 return nothing;
-            var expStm  = suiteStmt.stmts[0] as ExpStatement;
+            var expStm = suiteStmt.stmts[0] as ExpStatement;
             if (expStm == null)
                 return nothing;
             var str = expStm.Expression as Str;
@@ -265,7 +265,7 @@ namespace Pytocs.Translate
             {
                 var ex = e.Expression.Accept(xlat);
                 EnsureClassConstructor().Statements.Add(
-                    new CodeExpressionStatement( e.Expression.Accept(xlat)));
+                    new CodeExpressionStatement(e.Expression.Accept(xlat)));
             }
         }
 
@@ -337,9 +337,9 @@ namespace Pytocs.Translate
         private void ClassTranslator_GenerateField(Identifier id, ExpTranslator xlat, AssignExp ass)
         {
             IEnumerable<Exp> slotNames = null;
-            if (ass.Src is PyList srcList )
+            if (ass.Src is PyList srcList)
             {
-                slotNames= srcList.elts;
+                slotNames = srcList.elts;
             }
             else if (ass.Src is PyTuple srcTuple)
             {
@@ -395,14 +395,24 @@ namespace Pytocs.Translate
                 GenerateForTuple(f, tuple.values);
                 return;
             }
-            else if(f.exprs is AttributeAccess attributeAccess)
+            else if (f.exprs is AttributeAccess attributeAccess)
             {
-                var exp = f.exprs.Accept(xlat);
-                var v = f.tests.Accept(xlat);
-                gen.Foreach(exp, v, () => f.Body.Accept(this));
+                GenerateForAttributeAccess(f, attributeAccess.Expression);
                 return;
             }
             throw new NotImplementedException();
+        }
+
+        private void GenerateForAttributeAccess(ForStatement f, Exp id)
+        {
+            var localVar = GenSymLocalTuple();
+            var exp = f.exprs.Accept(xlat);
+            var v = f.tests.Accept(xlat);
+            gen.Foreach(localVar, v, () =>
+            {
+                gen.Assign(exp, localVar);
+                f.Body.Accept(this);
+            });
         }
 
         private void GenerateForTuple(ForStatement f, List<Exp> ids)
@@ -525,7 +535,7 @@ namespace Pytocs.Translate
 
         public void VisitPrint(PrintStatement p)
         {
-            CodeExpression e= null;
+            CodeExpression e = null;
             if (p.outputStream != null)
             {
                 e = p.outputStream.Accept(xlat);
@@ -639,7 +649,7 @@ namespace Pytocs.Translate
         private void GeneratePropertyGetter(Decorated getter)
         {
             var def = (FunctionDef)getter.Statement;
-            var mgen = new MethodGenerator(def,  null, def.parameters, false, gen);
+            var mgen = new MethodGenerator(def, null, def.parameters, false, gen);
             var comments = ConvertFirstStringToComments(def.body.stmts);
             gen.CurrentMemberComments.AddRange(comments);
             mgen.Xlat(def.body);
@@ -662,8 +672,8 @@ namespace Pytocs.Translate
                 gen.TypeRef(d.className.ToString()),
                 d.arguments.Select(a => new CodeAttributeArgument
                 {
-                     Name = a.name?.ToString(),
-                     Value = a.defval?.Accept(xlat),
+                    Name = a.name?.ToString(),
+                    Value = a.defval?.Accept(xlat),
                 }).ToArray());
         }
 

--- a/src/Translate/StatementTranslator.cs
+++ b/src/Translate/StatementTranslator.cs
@@ -385,14 +385,21 @@ namespace Pytocs.Translate
                 gen.Foreach(exp, v, () => f.Body.Accept(this));
                 return;
             }
-            if (f.exprs is ExpList expList)
+            else if (f.exprs is ExpList expList)
             {
                 GenerateForTuple(f, expList.Expressions);
                 return;
             }
-            if (f.exprs is PyTuple tuple)
+            else if (f.exprs is PyTuple tuple)
             {
                 GenerateForTuple(f, tuple.values);
+                return;
+            }
+            else if(f.exprs is AttributeAccess attributeAccess)
+            {
+                var exp = f.exprs.Accept(xlat);
+                var v = f.tests.Accept(xlat);
+                gen.Foreach(exp, v, () => f.Body.Accept(this));
                 return;
             }
             throw new NotImplementedException();


### PR DESCRIPTION
Hi
I tried to convert some python code and it had statements like this:
`for self.lineIndex in xrange(self.lineIndex, len(self.lines))`
This threw an exception and the conversion process stopped because `self.lineIndex` was not supported in the `for` statement.
So I added this case for a smooth run in the "for" translation code. The output seems to be right I compared a few code segments between the two languages. But I'm new here in this project and may easily have overlooked something or it could be simplified or better modularised.

Additional note:
There were also problems with not included operators "%=" "\\\\" and "\\\\=" which are also in my fork but not in this branch I request here to pull into your project. I can create a pull request for these also if you wish. But honestly I did this so the App does not fail. Probably the code conversion is not 100% correct because c# has no direct equivalent for the python "\\\\" operator as it seems.
